### PR TITLE
Fix GA expression

### DIFF
--- a/packages/ga/src/client.ts
+++ b/packages/ga/src/client.ts
@@ -21,7 +21,7 @@ function requestBuilder(jwtClient: any, viewId: string, pageConfig: PageConfig, 
       reportRequests: {
         pageSize: pageConfig.pageSize,
         pageToken: pageConfig.pageToken,
-        viewId: `ga:${viewId}`,
+        viewId,
         dateRanges: [
           {
             startDate: formatDate(period.startDate),

--- a/packages/ga/src/ga.ts
+++ b/packages/ga/src/ga.ts
@@ -4,7 +4,7 @@ import { Graph, Period } from '../../common/interfaces';
 
 const PageSize = 1000;
 const noop = (r: string) => r;
-const DefaultExpression = 'ga:users';
+const DefaultExpression = 'ga:pageviews';
 
 export interface FetchConfig {
   auth: any;


### PR DESCRIPTION
Fixes the default GA report expression and drops the redundant `ga:` prefix.