### PR TITLE
Collect nested routes in lazy modules

### DIFF
--- a/packages/parser/__tests__/angular.spec.ts
+++ b/packages/parser/__tests__/angular.spec.ts
@@ -1,6 +1,6 @@
 import { parseRoutes } from '../src/angular';
 
-const fixtureRoutes = new Set<string>(['/', '/bar', '/foo']);
+const fixtureRoutes = new Set<string>(['/', '/bar', '/foo', '/foo/index']);
 
 describe('Angular parser', () => {
   it('should parse an app', () => {
@@ -10,7 +10,7 @@ describe('Angular parser', () => {
   it('should produce routes', () => {
     const routes = parseRoutes('packages/parser/__tests__/fixtures/angular/src/tsconfig.app.json');
     expect(routes).toBeInstanceOf(Array);
-    expect(routes.map(r => r.path).reduce((c, route) => c && fixtureRoutes.has(route), true)).toEqual(true);
+    routes.map(r => r.path).forEach(r => expect(fixtureRoutes).toContain(r));
     expect(routes.length).toEqual(fixtureRoutes.size);
   });
 });

--- a/packages/parser/__tests__/fixtures/angular/src/app/foo/foo-routing.module.ts
+++ b/packages/parser/__tests__/fixtures/angular/src/app/foo/foo-routing.module.ts
@@ -6,6 +6,10 @@ const routes: Routes = [
   {
     path: '',
     component: FooComponent
+  },
+  {
+    path: 'index',
+    component: FooComponent
   }
 ];
 

--- a/packages/parser/__tests__/parser.spec.ts
+++ b/packages/parser/__tests__/parser.spec.ts
@@ -1,13 +1,13 @@
 import { parseRoutes } from '../';
 import { RoutingModule } from '../../common/interfaces';
 
-const angularFixtureRoutes = new Set<string>(['/', '/bar', '/foo']);
+const angularFixtureRoutes = new Set<string>(['/', '/bar', '/foo', '/foo/index']);
 const reactFixtureRoutes = new Set<string>(['/', '/intro', '/main', '/main/kid', '/main/parent']);
 
 describe('parseRoutes', () => {
   describe('auto detect Angular', () => {
     it('should recognize the app and return the routes', () => {
-      let routes: RoutingModule[];
+      let routes: RoutingModule[] = [];
       expect(() => (routes = parseRoutes('packages/parser/__tests__/fixtures/angular'))).not.toThrow();
       expect(routes.map(r => r.path).reduce((c, route) => c && angularFixtureRoutes.has(route), true)).toEqual(true);
       expect(routes.length).toEqual(angularFixtureRoutes.size);
@@ -16,7 +16,7 @@ describe('parseRoutes', () => {
 
   describe('auto detect React', () => {
     it('should recognize the app and return the routes', () => {
-      let routes: RoutingModule[];
+      let routes: RoutingModule[] = [];
       expect(() => (routes = parseRoutes('packages/parser/__tests__/fixtures/react-app'))).not.toThrow();
       expect(routes.map(r => r.path).reduce((c, route) => c && reactFixtureRoutes.has(route), true)).toEqual(true);
       expect(routes.length).toEqual(reactFixtureRoutes.size);
@@ -25,7 +25,7 @@ describe('parseRoutes', () => {
 
   describe('auto detect React TypeScript', () => {
     it('should recognize the app and return the routes', () => {
-      let routes: RoutingModule[];
+      let routes: RoutingModule[] = [];
       expect(() => (routes = parseRoutes('packages/parser/__tests__/fixtures/react-app-ts'))).not.toThrow();
       expect(routes.map(r => r.path).reduce((c, route) => c && reactFixtureRoutes.has(route), true)).toEqual(true);
       expect(routes.length).toEqual(reactFixtureRoutes.size);


### PR DESCRIPTION
Fix #44 

The issue was caused by not recursively traversing the child lazy routes. Basically, the route was pointing to `foo.module.ts#FooModule` which imports `foo-routing.module.ts#FooRoutingModule`. In the map, we had an entry for `foo-routing.module.ts#FooRoutingModule` but we didn't have one for `foo.module.ts#FooModule`. Now, both keys point to `foo-routing.module.ts#FooModule`.