### PR TITLE
Allow custom report provider

### DIFF
--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -66,7 +66,8 @@ new GuessPlugin({
   // Custom report provider. It is used for providing reports from a different source
   // other than Google Analytics. Keep in mind that you cannot specify both
   // `GA` and `reportProvider`. If `GA` is specified, then Guess.js will use the default
-  // Google Analytics report provider.
+  // Google Analytics report provider. For the format of the report, check the
+  // "Custom report provider" section below.
   reportProvider() {
     return new Promise((resolve, reject) => {
       readFile('./report.json', (err, content) => {
@@ -173,6 +174,42 @@ The `guess` function will return an object with keys the provided links and valu
 ```
 
 The `guess` function will not add values for the links it cannot find information for.
+
+## Custom report provider
+
+The `reportProvider` configuration property of `GuessPlugin` is a function which returns promise that resolves to the following data structure:
+
+```ts
+export interface PageTransitions {
+  [key: string]: number;
+}
+
+export interface Report {
+  [key: string]: PageTransitions;
+}
+```
+
+Here's an example:
+
+```ts
+{
+  "foo": {
+    "bar": 5,
+    "baz" 2
+  },
+  "bar": {
+    "baz": 3
+  }
+}
+```
+
+The meaning of the report above is:
+
+* There are two reported transitions from page `foo`:
+  * Transition to page `bar` which has occurred 5 times.
+  * Transition to page `baz` which has occurred 2 times.
+* There's one reported transition from page `bar`:
+  * Transition to `baz` which has occurred 3 times.
 
 ## Demos
 

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -58,8 +58,26 @@ You may also want to pass a custom time period:
 
 ```ts
 new GuessPlugin({
-  // View ID of the GA application
+  // View ID of the GA application. Alternatively, you can use `reportProvider`
+  // if you want to extract the report from the file system or a different source,
+  // other than Google Analytics.
   GA: 'GA_VIEW_ID',
+
+  // Custom report provider. It is used for providing reports from a different source
+  // other than Google Analytics. Keep in mind that you cannot specify both
+  // `GA` and `reportProvider`. If `GA` is specified, then Guess.js will use the default
+  // Google Analytics report provider.
+  reportProvider() {
+    return new Promise((resolve, reject) => {
+      readFile('./report.json', (err, content) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(JSON.stringify(content.toString()));
+      })
+    });
+  }
 
   // The mode provides hint to the `guess-parser` how your application
   // should be parsed in order to extract the routes and map them


### PR DESCRIPTION
This PR allows us to specify custom report provider. This way, for code-labs we can share an already available report in the form of a file.