### PR TITLE
Adds typescript as a peer dependency of guess-parser

### DIFF
--- a/packages/guess-parser/package.json
+++ b/packages/guess-parser/package.json
@@ -30,6 +30,9 @@
     "rxjs": "^6.0.0",
     "zone.js": "~0.8.26"
   },
+  "peerDependencies": {
+    "typescript": "~2.7.2"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
**What**:

`typescript` is added as a peer dependency. I've picked `~2.7.2` because it's the most restrictive request from your dependencies (via `ngast`).

**Why**:

`@angular/cli` and `ngast` both have a peer dependency on `typescript`, but this package doesn't provide it - which is [invalid](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0).
