### PR TITLE
fix(guess-ga): fix infinite loop on nextPage

### DIFF
--- a/packages/guess-ga/src/client.ts
+++ b/packages/guess-ga/src/client.ts
@@ -1,4 +1,4 @@
-import { Period } from "../../common/interfaces";
+import { Period } from '../../common/interfaces';
 
 interface PageConfig {
   pageToken: number | undefined;
@@ -10,20 +10,11 @@ interface AnalyticsResult {
   nextPage: number;
 }
 
-const formatNumber = (n: number) => (n.toString().length === 1 ? "0" + n : n);
+const formatNumber = (n: number) => (n.toString().length === 1 ? '0' + n : n);
 
-const formatDate = (d: Date) =>
-  `${d.getFullYear()}-${formatNumber(d.getMonth() + 1)}-${formatNumber(
-    d.getDate()
-  )}`;
+const formatDate = (d: Date) => `${d.getFullYear()}-${formatNumber(d.getMonth() + 1)}-${formatNumber(d.getDate())}`;
 
-function requestBuilder(
-  jwtClient: any,
-  viewId: string,
-  pageConfig: PageConfig,
-  period: Period,
-  expression: string
-) {
+function requestBuilder(jwtClient: any, viewId: string, pageConfig: PageConfig, period: Period, expression: string) {
   return {
     auth: jwtClient,
     resource: {
@@ -37,9 +28,9 @@ function requestBuilder(
             endDate: formatDate(period.endDate)
           }
         ],
-        dimensions: [{ name: "ga:previousPagePath" }, { name: "ga:pagePath" }],
+        dimensions: [{ name: 'ga:previousPagePath' }, { name: 'ga:pagePath' }],
         metrics: [{ expression }],
-        orderBys: [{ fieldName: expression, sortOrder: "DESCENDING" }]
+        orderBys: [{ fieldName: expression, sortOrder: 'DESCENDING' }]
       }
     }
   };
@@ -54,27 +45,26 @@ async function fetchReport(
   expression: string
 ) {
   return new Promise<AnalyticsResult>((resolve, reject) => {
-    client.reports.batchGet(
-      requestBuilder(jwtClient, viewId, pageConfig, period, expression),
-      function(err: any, response: any) {
-        if (err) {
-          reject(err);
-          return;
-        }
-        const nextPage = response.data.reports[0].nextPageToken;
-        const report = response.data.reports[0];
-        resolve({
-          report,
-          nextPage
-        });
+    client.reports.batchGet(requestBuilder(jwtClient, viewId, pageConfig, period, expression), function(
+      err: any,
+      response: any
+    ) {
+      if (err) {
+        reject(err);
+        return;
       }
-    );
+      const nextPage = response.data.reports[0].nextPageToken;
+      const report = response.data.reports[0];
+      resolve({
+        report,
+        nextPage
+      });
+    });
   });
 }
 
-if (typeof (Symbol as any).asyncIterator === "undefined") {
-  (Symbol as any).asyncIterator =
-    Symbol.asyncIterator || Symbol("asyncIterator");
+if (typeof (Symbol as any).asyncIterator === 'undefined') {
+  (Symbol as any).asyncIterator = Symbol.asyncIterator || Symbol('asyncIterator');
 }
 
 export type GaResult = any;
@@ -84,15 +74,9 @@ export interface ClientResult {
   report?: any;
 }
 
-export function getClient(
-  jwtClient: any,
-  pageSize: number,
-  viewId: string,
-  period: Period,
-  expression: string
-) {
-  const { google } = require("googleapis");
-  const client = google.analyticsreporting("v4");
+export function getClient(jwtClient: any, pageSize: number, viewId: string, period: Period, expression: string) {
+  const { google } = require('googleapis');
+  const client = google.analyticsreporting('v4');
   const pageConfig: PageConfig = {
     pageSize,
     pageToken: undefined
@@ -102,21 +86,14 @@ export function getClient(
     while (true) {
       const clientResult: ClientResult = {};
       try {
-        const result = await fetchReport(
-          client,
-          jwtClient,
-          viewId,
-          pageConfig,
-          period,
-          expression
-        );
+        const result = await fetchReport(client, jwtClient, viewId, pageConfig, period, expression);
         clientResult.report = result.report;
         pageConfig.pageToken = result.nextPage;
       } catch (e) {
         clientResult.error = e;
       }
       yield clientResult;
-      if (!pageConfig.pageToken || clientResult.error) {
+      if (!pageConfig.pageToken) {
         break;
       }
     }


### PR DESCRIPTION
I've discovered a bug while implementing this on https://www.gatsbyjs.org. It seems like there is an infinite loop while fetching ga data when any page besides the first does not have a nextPage property.

I was trying to create some tests for it but the current jest setup does not allow it as packages are not hoisted.


example:
first request returns:
```json
{
  "columnHeader": {
  },
  "data": {
  },
  "nextPageToken": "10000"
}
```

next request returns:
```json
{
  "columnHeader": {
  },
  "data": {
  },
}
```

it will keep on looping with pageToken "10000"