### PR TITLE
fix(guess-webpack): runtime compatibility es2015

### DIFF
--- a/packages/guess-webpack/src/runtime/guess.ts
+++ b/packages/guess-webpack/src/runtime/guess.ts
@@ -74,7 +74,7 @@ const matchRoute = (route: string, declaration: string) => {
     return false;
   } else {
     return declarationParts.reduce((a, p, i) => {
-      if (p.startsWith(':')) {
+      if (p[0] === ':') {
         return a;
       }
       return a && p === routeParts[i];


### PR DESCRIPTION
startWith is not in the es2015 spec which means IE11 breaks here. [IE11 supports prefetch](https://caniuse.com/#search=prefetch) which is why in my opinion runtime should be compatible with IE11.

The problem lies with typescript nor babel transpiles or polyfill the `startWith` function. This replaces `startWith` with `[0]` as we only check the first character.

If you feel like we should polyfill this instead of changing guess itself, feel free to close this one. 