### PR TITLE
chore: rework externals regex in webpack to support windows

### DIFF
--- a/packages/guess-ga/webpack.config.js
+++ b/packages/guess-ga/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
     filename: './guess-ga/index.js',
     libraryTarget: 'umd'
   },
-  externals: [/^(@|\w{4}(?<!\w:\\\\)).*$/i],
+  externals: [/^(@|\w{3}(?<!\w:\\)).*$/i],
   resolve: {
     // Add `.ts` and `.tsx` as a resolvable extension.
     extensions: ['.ts', '.js', '.json']

--- a/packages/guess-ga/webpack.config.js
+++ b/packages/guess-ga/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
     filename: './guess-ga/index.js',
     libraryTarget: 'umd'
   },
-  externals: [/^(@|\w).*$/i],
+  externals: [/^(@|\w{4}(?<!\w:\\\\)).*$/i],
   resolve: {
     // Add `.ts` and `.tsx` as a resolvable extension.
     extensions: ['.ts', '.js', '.json']

--- a/packages/guess-parser/webpack.config.js
+++ b/packages/guess-parser/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
     filename: './guess-parser/index.js',
     libraryTarget: 'umd'
   },
-  externals: [/^(@|\w).*$/i],
+  externals: [/^(@|\w{4}(?<!\w:\\\\)).*$/i],
   resolve: {
     // Add `.ts` and `.tsx` as a resolvable extension.
     extensions: ['.ts', '.js']

--- a/packages/guess-parser/webpack.config.js
+++ b/packages/guess-parser/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
     filename: './guess-parser/index.js',
     libraryTarget: 'umd'
   },
-  externals: [/^(@|\w{4}(?<!\w:\\\\)).*$/i],
+  externals: [/^(@|\w{3}(?<!\w:\\)).*$/i],
   resolve: {
     // Add `.ts` and `.tsx` as a resolvable extension.
     extensions: ['.ts', '.js']

--- a/packages/guess-webpack/webpack.config.js
+++ b/packages/guess-webpack/webpack.config.js
@@ -2,7 +2,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const common = {
   mode: 'production',
-  externals: [/^(@|\w).*$/i],
+  externals: [/^(@|\w{4}(?<!\w:\\\\)).*$/i],
   resolve: {
     extensions: ['.ts', '.tsx', '.js']
   },
@@ -17,7 +17,7 @@ const common = {
 module.exports = [
   {
     mode: 'production',
-    externals: [/^(@|\w).*$/i],
+    externals: [/^(@|\w{4}(?<!\w:\\\\)).*$/i],
     entry: `${__dirname}/api/index.ts`,
     output: {
       filename: 'api/index.js',

--- a/packages/guess-webpack/webpack.config.js
+++ b/packages/guess-webpack/webpack.config.js
@@ -2,7 +2,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const common = {
   mode: 'production',
-  externals: [/^(@|\w{4}(?<!\w:\\\\)).*$/i],
+  externals: [/^(@|\w{3}(?<!\w:\\)).*$/i],
   resolve: {
     extensions: ['.ts', '.tsx', '.js']
   },
@@ -17,7 +17,7 @@ const common = {
 module.exports = [
   {
     mode: 'production',
-    externals: [/^(@|\w{4}(?<!\w:\\\\)).*$/i],
+    externals: [/^(@|\w{3}(?<!\w:\\)).*$/i],
     entry: `${__dirname}/api/index.ts`,
     output: {
       filename: 'api/index.js',


### PR DESCRIPTION
when trying to build guess-webpack, .ts files were used as externals which broke the bundle when using it. On windows, file path requests are using `c:\` or `d:\` which fit the `\w` regex. On Linux/mac we start with a `/`. Now I check if a package starts with `@` and do not start with `c:\` it's an external package.

To test:
regex: `/^(@|\w{3}(?<!\w:\\)).*$/igm`
```
@test
jquery
mypackage
c:\
```