### PR TITLE
[guess-parser] handle Angular apps without any routes

### DIFF
--- a/packages/guess-parser/src/angular/index.ts
+++ b/packages/guess-parser/src/angular/index.ts
@@ -489,7 +489,9 @@ export const parseRoutes = (tsconfig: string, exclude: string[] = []): RoutingMo
   });
 
   const result: RoutingModule[] = [];
-  collectRoutingModules(findRootModule(registry), registry, result);
+  if (Object.keys(registry).length > 0) {
+    collectRoutingModules(findRootModule(registry), registry, result);
+  }
 
   return result;
 };


### PR DESCRIPTION
I noticed a little regression in the latest version (v.0.3.10) of guess-parser. Previously it was possible to parse an Angular app which did not contain any routes. When calling `parseAngularRoutes(pathToTsConfig)` it did just return an empty array. But the newest version of guess-parser throws an error instead.

I added a simple check to restore the old behavior. However I don't know if this was the most clever thing I could do. Please let me know if there is a better way of doing it.

I would also be happy to add a test for that edge case if you think it is necessary.