### PR TITLE
Do not include base path in each instruction

### DIFF
--- a/infra/e2e.ts
+++ b/infra/e2e.ts
@@ -35,6 +35,12 @@ if (mainModule.indexOf('__GUESS__.p(') < 0 || mainModule.indexOf('__GUESS__.p=')
   process.exit(1);
 }
 
+// No base
+if (mainModule.indexOf('"http://localhost:1337"') < 0) {
+  console.error('Unable to find the base path');
+  process.exit(1);
+}
+
 // Prod build should work
 console.log(execSync(
   `${enterTest} && ./node_modules/.bin/ng build --prod --extra-webpack-config webpack.extra.js`

--- a/packages/guess-webpack/src/aot/aot.tpl
+++ b/packages/guess-webpack/src/aot/aot.tpl
@@ -1,5 +1,5 @@
 import { initialize } from './guess-aot';
 
-(function(g, thresholds) {
-  initialize(g, thresholds);
-})(typeof window === 'undefined' ? global : window, <%= THRESHOLDS %>);
+(function(g, thresholds, base) {
+  initialize(g, thresholds, base);
+})(typeof window === 'undefined' ? global : window, <%= THRESHOLDS %>, '<%= BASE_PATH %>');

--- a/packages/guess-webpack/src/aot/guess-aot.ts
+++ b/packages/guess-webpack/src/aot/guess-aot.ts
@@ -35,7 +35,9 @@ const supportedPrefetchStrategy = support('prefetch')
 const preFetched: { [key: string]: boolean } = {};
 
 const prefetch = (basePath: string, url: string) => {
-  url = basePath + url;
+  if (basePath) {
+    url = basePath + '/' + url;
+  }
   if (preFetched[url]) {
     return;
   }
@@ -50,14 +52,14 @@ const getConnection = (global: any): ConnectionEffectiveType => {
   return global.navigator.connection.effectiveType || '3g';
 };
 
-export const initialize = (g: any, t: PrefetchConfig) => {
+export const initialize = (g: any, t: PrefetchConfig, base?: string) => {
   const idle = g.requestIdleCallback || ((cb: Function) => setTimeout(cb, 0));
   g.__GUESS__ = {};
   g.__GUESS__.p = (...p: [number, string][]) => {
     idle(() =>
       p.forEach(c =>
         c[0] >= t[getConnection(g)]
-          ? c.slice(1).forEach(f => prefetch('', f as string))
+          ? c.slice(1).forEach(f => prefetch(base || '', f as string))
           : void 0
       )
     );

--- a/packages/guess-webpack/src/declarations.ts
+++ b/packages/guess-webpack/src/declarations.ts
@@ -80,7 +80,7 @@ export interface PrefetchAotGraph {
 export interface PrefetchAotPluginConfig {
   debug?: boolean;
   data: Graph;
-  basePath: string;
+  base: string;
   prefetchConfig?: PrefetchConfig;
   routes: RoutingModule[];
 }

--- a/packages/guess-webpack/src/guess-webpack.ts
+++ b/packages/guess-webpack/src/guess-webpack.ts
@@ -7,7 +7,7 @@ import { AssetObserver } from './asset-observer';
 
 export interface RuntimeConfig {
   /** @internal */
-  basePath?: string;
+  base?: string;
   /** @internal */
   prefetchConfig?: PrefetchConfig;
   /** @internal */
@@ -126,9 +126,9 @@ export class GuessPlugin {
         data,
         debug: this._config.debug,
         basePath: runtime
-          ? runtime.basePath === undefined
+          ? runtime.base === undefined
             ? ''
-            : runtime.basePath
+            : runtime.base
           : '',
         prefetchConfig: runtime ? runtime.prefetchConfig : undefined,
         routes,
@@ -138,10 +138,10 @@ export class GuessPlugin {
       new PrefetchAotPlugin({
         data,
         debug: this._config.debug,
-        basePath: runtime
-          ? runtime.basePath === undefined
+        base: runtime
+          ? runtime.base === undefined
             ? ''
-            : runtime.basePath
+            : runtime.base
           : '',
         prefetchConfig: runtime ? runtime.prefetchConfig : undefined,
         routes

--- a/packages/guess-webpack/src/prefetch-aot-plugin.ts
+++ b/packages/guess-webpack/src/prefetch-aot-plugin.ts
@@ -81,13 +81,6 @@ const alterChunk = (
   });
 };
 
-const joinUrl = (basePath: string, chunk: string) => {
-  if (basePath) {
-    return basePath + '/' + chunk;
-  }
-  return chunk;
-};
-
 export class PrefetchAotPlugin {
   private logger = new Logger();
   constructor(private _config: PrefetchAotPluginConfig) {
@@ -199,7 +192,7 @@ export class PrefetchAotPlugin {
       return [
         c.probability,
         `[${c.probability},${c.chunks
-          .map(chunk => `'${joinUrl(this._config.basePath, chunk)}'`)
+          .map(chunk => `'${chunk}'`)
           .join(',')}]`
       ];
     };
@@ -258,7 +251,8 @@ export class PrefetchAotPlugin {
               defaultPrefetchConfig,
               this._config.prefetchConfig
             )
-          )
+          ),
+          BASE_PATH: this._config.base
         });
         newCode = prefetchingLogic + ';' + newCode;
         this.logger.debug('Altering the main chunk');

--- a/packages/guess-webpack/test/fixtures/angular/webpack.extra.js
+++ b/packages/guess-webpack/test/fixtures/angular/webpack.extra.js
@@ -8,6 +8,9 @@ module.exports = {
       reportProvider() {
         return Promise.resolve(JSON.parse(require('fs').readFileSync('./routes.json').toString()));
       },
+      runtime: {
+        base: 'http://localhost:1337'
+      },
       routeProvider() {
         return parseRoutes('.');
       }


### PR DESCRIPTION
This should shrink bundles with lots of instructions. It also introduces a breaking config change:

```ts
{
  runtime: {
    basePath: '...'
  }
}
```

is now:

```ts
{
  runtime: {
    base: '...'
  }
}
```