### PR TITLE
[guess-parser] handle nx-style monorepos

### DIFF
--- a/packages/guess-parser/src/angular/index.ts
+++ b/packages/guess-parser/src/angular/index.ts
@@ -4,6 +4,14 @@ import { existsSync, readFileSync } from 'fs';
 import { dirname, resolve, join, sep } from 'path';
 import { evaluate } from '@wessberg/ts-evaluator';
 
+const isImportDeclaration = (node: ts.Node): node is ts.ImportDeclaration => {
+  return node.kind === ts.SyntaxKind.ImportDeclaration;
+};
+
+const isReExportDeclaration = (node: ts.Node): node is ts.ExportDeclaration => {
+  return (node.kind === ts.SyntaxKind.ExportDeclaration && (node as ts.ExportDeclaration).exportClause === undefined);
+};
+
 const imports = (
   parent: string,
   child: string,
@@ -23,11 +31,10 @@ const imports = (
     if (found) {
       return;
     }
-    if (n.kind !== ts.SyntaxKind.ImportDeclaration) {
+    if (!isImportDeclaration(n) && !isReExportDeclaration(n)) {
       return;
     }
-    const imprt = n as ts.ImportDeclaration;
-    const path = (imprt.moduleSpecifier as ts.StringLiteral).text;
+    const path = (n.moduleSpecifier as ts.StringLiteral).text;
     const fullPath = join(dirname(parent), path) + '.ts';
     if (fullPath === child) {
       found = true;

--- a/packages/guess-parser/test/angular.spec.ts
+++ b/packages/guess-parser/test/angular.spec.ts
@@ -7,6 +7,7 @@ const fixtureRoutes = new Set<string>([
   '/foo/baz/index',
   '/bar/baz',
   '/qux',
+  '/library',
   '/bar-simple'
 ]);
 

--- a/packages/guess-parser/test/fixtures/angular/library/index.ts
+++ b/packages/guess-parser/test/fixtures/angular/library/index.ts
@@ -1,0 +1,1 @@
+export * from './library.module';

--- a/packages/guess-parser/test/fixtures/angular/library/library.module.ts
+++ b/packages/guess-parser/test/fixtures/angular/library/library.module.ts
@@ -1,0 +1,20 @@
+import { NgModule, Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+@Component({
+
+})
+class LibraryComponent {}
+
+@NgModule({
+  declarations: [LibraryComponent],
+  imports: [RouterModule.forChild([
+    {
+      path: '',
+      component: LibraryComponent,
+      pathMatch: 'full'
+    }
+  ])],
+  bootstrap: [LibraryComponent]
+})
+export class LibraryModule {}

--- a/packages/guess-parser/test/fixtures/angular/library/tsconfig.json
+++ b/packages/guess-parser/test/fixtures/angular/library/tsconfig.json
@@ -1,12 +1,9 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../out-tsc/app",
+    "outDir": "../out-tsc/library",
     "module": "es2015",
     "types": []
   },
-  "exclude": [
-    "test.ts",
-    "**/*.spec.ts"
-  ]
+  "include": ["**/*.ts"]
 }

--- a/packages/guess-parser/test/fixtures/angular/src/app/app-routing.module.ts
+++ b/packages/guess-parser/test/fixtures/angular/src/app/app-routing.module.ts
@@ -33,6 +33,10 @@ const routes: Routes = [
     loadChildren: 'app/qux/qux.module#QuxModule'
   },
   {
+    path: 'library',
+    loadChildren: 'app/wrapper/wrapper.module#WrapperModule'
+  },
+  {
     path: 'bar-simple',
     component: BarSimpleComponent
   },

--- a/packages/guess-parser/test/fixtures/angular/src/app/wrapper/wrapper.module.ts
+++ b/packages/guess-parser/test/fixtures/angular/src/app/wrapper/wrapper.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { LibraryModule } from '~library';
+
+@NgModule({
+  imports: [LibraryModule]
+})
+export class WrapperModule {}
+
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';

--- a/packages/guess-parser/test/fixtures/angular/src/tsconfig.spec.json
+++ b/packages/guess-parser/test/fixtures/angular/src/tsconfig.spec.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "../out-tsc/spec",
-    "baseUrl": "./",
     "module": "commonjs",
     "types": [
       "jasmine",

--- a/packages/guess-parser/test/fixtures/angular/tsconfig.json
+++ b/packages/guess-parser/test/fixtures/angular/tsconfig.json
@@ -14,6 +14,10 @@
     "lib": [
       "es2017",
       "dom"
-    ]
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "~library": ["library/index.ts"],
+    }
   }
 }

--- a/packages/guess-parser/test/parser.spec.ts
+++ b/packages/guess-parser/test/parser.spec.ts
@@ -8,6 +8,7 @@ const angularFixtureRoutes = new Set<string>([
   '/foo/baz/index',
   '/bar/baz',
   '/qux',
+  '/library',
   '/bar-simple'
 ]);
 


### PR DESCRIPTION
This pull request will add support for parsing Angular applications developed with [nrwl/nx](https://github.com/nrwl/nx). Typically those applications use barrel files and set the paths property  in the tsconfig files to rewrite imports.

The first commit is meant to handle barrel files. It makes sure that `export * from './foo.ts';` counts as an import statement. I found the info that `exportClause` will be undefined for those exports in the TypeScript source code: https://github.com/microsoft/TypeScript/blob/master/src/compiler/types.ts#L2459

The second commit makes sure that `resolveModuleName` from TypeScript is used to resolve the full path of each import. This will resolve imports which refer to a local project like `import { AnyModule } from '@mylocalproject/library';`.

I have not added any tests so far since I'm not really sure where to start. But I'm happy to add tests if you could give me a little hint on where to start. A least I did not break any existing tests.

Please let me know if there is anything else I need to change.

Just for reference. These changes are meant to ultimately fix an issue filed agains [angular-prerender](https://github.com/chrisguttandin/angular-prerender): https://github.com/chrisguttandin/angular-prerender/issues/87