### PR TITLE
fix(guess-parser-angular): readChildren

### DIFF
--- a/packages/guess-parser/src/angular/index.ts
+++ b/packages/guess-parser/src/angular/index.ts
@@ -218,8 +218,7 @@ const getRoute = (
   const childrenArray = readChildren(node, program.getTypeChecker());
   let children: Route[] = [];
   if (childrenArray) {
-    children = childrenArray
-      .getChildren()
+    children = (childrenArray.getChildren ? childrenArray.getChildren() : childrenArray as unknown as ts.Node[])
       .map(c => {
         if (c.kind !== ts.SyntaxKind.ObjectLiteralExpression) {
           return null;


### PR DESCRIPTION
Not the most beautiful fix and we should dig deeper in it but it works.

- readChildren returns already nodes on some typescript versions