### PR TITLE
[guess-parser] Fix module resolution of nested modules

### DIFF
--- a/packages/guess-parser/src/angular/index.ts
+++ b/packages/guess-parser/src/angular/index.ts
@@ -36,7 +36,7 @@ const imports = (
       return;
     }
     const path = (n.moduleSpecifier as ts.StringLiteral).text;
-    const { resolvedModule } = ts.resolveModuleName(path, child, program.getCompilerOptions(), host);
+    const { resolvedModule } = ts.resolveModuleName(path, parent, program.getCompilerOptions(), host);
     if (resolvedModule !== undefined) {
       const fullPath = resolvedModule.resolvedFileName;
 

--- a/packages/guess-parser/test/fixtures/angular/library/index.ts
+++ b/packages/guess-parser/test/fixtures/angular/library/index.ts
@@ -1,1 +1,1 @@
-export * from './library.module';
+export * from './nested/library.module';

--- a/packages/guess-parser/test/fixtures/angular/library/nested/library.module.ts
+++ b/packages/guess-parser/test/fixtures/angular/library/nested/library.module.ts
@@ -1,0 +1,20 @@
+import { NgModule, Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+@Component({
+
+})
+class LibraryComponent {}
+
+@NgModule({
+  declarations: [LibraryComponent],
+  imports: [RouterModule.forChild([
+    {
+      path: '',
+      component: LibraryComponent,
+      pathMatch: 'full'
+    }
+  ])],
+  bootstrap: [LibraryComponent]
+})
+export class LibraryModule {}


### PR DESCRIPTION
Unfortunately I made a mistake in my last pull request. `resolveModuleName()` was called with the `child` instead of the `parent`. This wasn't noticeable with the previous fixture. But it surfaces when we nest the library module in yet another folder. I updated the fixture to reflect that.

Please let me know if there is anything I need to change.