### PR TITLE
Normalize paths provided by TypeScript

### DIFF
--- a/packages/guess-parser/src/angular/index.ts
+++ b/packages/guess-parser/src/angular/index.ts
@@ -12,6 +12,10 @@ const isReExportDeclaration = (node: ts.Node): node is ts.ExportDeclaration => {
   return (node.kind === ts.SyntaxKind.ExportDeclaration && (node as ts.ExportDeclaration).exportClause === undefined);
 };
 
+const normalizeFilePath = (path: string): string => {
+  return join(...path.split(/\//).map((part, index) => (part === '' && index === 0) ? sep : part));
+};
+
 const imports = (
   parent: string,
   child: string,
@@ -38,7 +42,7 @@ const imports = (
     const path = (n.moduleSpecifier as ts.StringLiteral).text;
     const { resolvedModule } = ts.resolveModuleName(path, parent, program.getCompilerOptions(), host);
     if (resolvedModule !== undefined) {
-      const fullPath = resolvedModule.resolvedFileName;
+      const fullPath = normalizeFilePath(resolvedModule.resolvedFileName);
 
       if (fullPath === child) {
         found = true;


### PR DESCRIPTION
This pull request is intended to fix a problem with inconsistent file paths. As it turns out TypeScript always uses slashes ("/") in file paths no matter which operating system is used. But the rest of the code is using the separator of the operating system. This becomes a problem when two paths need to be compared.

I found the information that TypeScript always uses slashes in the source code of TypeScript itself: https://github.com/microsoft/TypeScript/blob/master/src/compiler/path.ts#L4. "Internally, we represent paths as strings with '/' as the directory separator."

These changes are also intended to fix chrisguttandin/angular-prerender#88.