### PR TITLE
fix: change typescript peer dependency to a loose patch

### DIFF
--- a/packages/guess-parser/package.json
+++ b/packages/guess-parser/package.json
@@ -29,7 +29,7 @@
     "ts-loader": "6.2.1"
   },
   "peerDependencies": {
-    "typescript": "3.7.5"
+    "typescript": "~3.7.5"
   },
   "files": [
     "dist"


### PR DESCRIPTION
If a specific pinned version is required it is better off as a direct dependency. 