### PR TITLE
Fix filename for generate-prediction-tests script in package.json

### DIFF
--- a/experiments/guess-static-sites/package.json
+++ b/experiments/guess-static-sites/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "generate-predictions-tests": "NODE_ENV=test mocha ./test/gaclientTests.js",
+    "generate-predictions-tests": "NODE_ENV=test mocha ./test/gaClientTests.js",
     "client-tests": "NODE_ENV=test mocha ./test/clientTests.js",
     "server-tests": "NODE_ENV=test mocha ./test/serverTests.js",
     "build": "babel src/client.js --out-file dist/client.js --presets minify"


### PR DESCRIPTION
Fix filename for generate-prediction-tests script in package.json in guess-static-sites experiment.