### PR TITLE
Adds windows file path format support when parsing routes

### DIFF
--- a/packages/guess-parser/src/angular/index.ts
+++ b/packages/guess-parser/src/angular/index.ts
@@ -199,7 +199,7 @@ const getModulePathFromRoute = (parentPath: string, loadChildren: string, progra
   const childModule = loadChildren.split('#')[0];
   const { resolvedModule } = ts.resolveModuleName(childModule, parentPath, program.getCompilerOptions(), host);
   if (resolvedModule) {
-    return resolvedModule.resolvedFileName;
+    return normalizeFilePath(resolvedModule.resolvedFileName);
   }
   const childModuleFile = childModule + '.ts';
   const parentSegments = dirname(parentPath).split(sep);
@@ -487,7 +487,7 @@ export const parseRoutes = (
   const typeChecker = program.getTypeChecker();
 
   const toAbsolute = (file: string) =>
-    file.startsWith('/') ? file : join(process.cwd(), file);
+    file.startsWith('/') || file.startsWith(process.cwd()) ? file : join(process.cwd(), file);
   const excludeFiles = new Set<string>(exclude.map(toAbsolute));
 
   const visitTopLevelRoutes = (


### PR DESCRIPTION
Windows uses the `'\'` in its file names. I ran into a couple places where this wasn't taken into account.

1) Parsing routes in my angular app on my windows machine would fail when matching the TypeScript resolved modules file name to the OS file name (like `line 337`). 

    I fixed this by normalizing the resolved file name using the `normalizeFilePath` method which was the process utilized by the `imports()` method above.

2) On line 236-9, I didn't know if the `split('/') ... join('/')` should use `path.sep` instead of '/'. My use case never falls through to this code and I didn't want to assume so I left it alone.

3) Mapping the excluded files to an absolute path was broken on windows because an absolute path on windows starts with the directory (eg `c:\` or `d:\`) not a `/` like linux systems so `file.startsWith('/')` was not sufficient. This map resulted in an excluded file name like `c:\exluded\path\to\file` being rewritten to `c:\exluded\path\c:\exluded\path\to\file`.

    To fix this, I added `|| file.startsWith(process.cwd())` to the ternary. I wonder, however, if this would have been better just using the `path.resolve()` method.


_PS> I just read the code of conduct. I am sorry I didn't ask about fixing this before doing it. I hope it's not a bother. I found these issues while trying to get a Scully.io build to work on my windows machine. There is a workaround that works on a Linux emulator like `git bash` but this solution won't work on our build machines. Thanks for your consideration!_