### PR TITLE
fix: handle lazy loaded routes which are children of eager routes

### DIFF
--- a/packages/guess-parser/test/angular.spec.ts
+++ b/packages/guess-parser/test/angular.spec.ts
@@ -12,6 +12,8 @@ const fixtureRoutes = new Set([
   '/foo/child1',
   '/foo/foo-parent',
   '/foo/foo-parent/child2',
+  '/eager',
+  '/eager/lazy',
 ]);
 
 const nxRoutes = new Set([

--- a/packages/guess-parser/test/fixtures/angular/src/app/app-routing.module.ts
+++ b/packages/guess-parser/test/fixtures/angular/src/app/app-routing.module.ts
@@ -45,6 +45,15 @@ const routes: Routes = [
     loadChildren: () => import('./about/about.module').then(m => m.AboutModule)
   },
   {
+    path: 'eager',
+    children: [
+      {
+        path: 'lazy',
+        loadChildren: () => import('./lazy/lazy.module').then(m => m.LazyModule)
+      }
+    ]
+  },
+  {
     path: '',
     pathMatch: 'full',
     redirectTo: 'bar'

--- a/packages/guess-parser/test/fixtures/angular/src/app/lazy/lazy-routing.module.ts
+++ b/packages/guess-parser/test/fixtures/angular/src/app/lazy/lazy-routing.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { LazyComponent } from './lazy.component';
+
+const routes: Routes = [{ path: '', component: LazyComponent }];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class LazyRoutingModule {}

--- a/packages/guess-parser/test/fixtures/angular/src/app/lazy/lazy.component.ts
+++ b/packages/guess-parser/test/fixtures/angular/src/app/lazy/lazy.component.ts
@@ -1,0 +1,6 @@
+import { Component } from '@angular/core';
+
+@Component({
+  template: '',
+})
+export class LazyComponent { }

--- a/packages/guess-parser/test/fixtures/angular/src/app/lazy/lazy.module.ts
+++ b/packages/guess-parser/test/fixtures/angular/src/app/lazy/lazy.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { LazyRoutingModule } from './lazy-routing.module';
+import { LazyComponent } from './lazy.component';
+
+@NgModule({
+  declarations: [
+    LazyComponent
+  ],
+  imports: [
+    CommonModule,
+    LazyRoutingModule
+  ]
+})
+export class LazyModule { }

--- a/packages/guess-parser/test/parser.spec.ts
+++ b/packages/guess-parser/test/parser.spec.ts
@@ -13,6 +13,8 @@ const angularFixtureRoutes = new Set<string>([
   '/foo/child1',
   '/foo/foo-parent',
   '/foo/foo-parent/child2',
+  '/eager',
+  '/eager/lazy',
 ]);
 
 const reactFixtureRoutes = new Set<string>(['/', '/intro', '/main', '/main/kid', '/main/parent']);


### PR DESCRIPTION
The changes introduced by this pull request aim to fix a bug which was originally reported for angular-prerender (chrisguttandin/angular-prerender#112). It might also fix #315 and #336 as the reports look fairly similar.

The problem was that guess-parser did not look recursively for entry points so far. Therefore I introduced the `collectEntryPoints()` function which keeps on looking for entry points as long as there are children in the currently handled route definition.

I also removed a part of the `readChildren()` function as it was returning wrong results. Apparently removing  the `evaluate()` call did resolve the issue. Please let me know if there is a better way to fix this.