### PR TITLE
Docs: Fix link to LinkRelPrefetch usage on chrome platform status

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ By collaborating across different touch-points in the ecosystem where data-drive
 * These decisions are often made at a point in time and..
   * (1) are often not revisited as data trends change
   * (2) are very limited in how they are used. Implementations will often only prefetch content from a homepage or very small set of hero pages, but otherwise not do this for all of the possible entry points on a site. This can leave performance opportunities on the table.
-  * (3) Require some amount of confidence about the data being used to drive decisions around using prefetching means that developers may not be adopting it out of worry they will waste bandwidth. `<link rel=prefetch>` is [currently used on 5%](https://www.chromestatus.com/metrics/feature/popularity%23LinkRelPrefetch?sa=D&ust=1522637949795000) of total Chrome pageloads, but this could be higher.
+  * (3) Require some amount of confidence about the data being used to drive decisions around using prefetching means that developers may not be adopting it out of worry they will waste bandwidth. `<link rel=prefetch>` is [currently used on 5%](https://www.chromestatus.com/metrics/feature/timeline/popularity/917) of total Chrome pageloads, but this could be higher.
 * Implementing predictive analytics is too complex for the average web developer.
   * Most developers are unfamiliar with how to leverage the [Google Analytics API](https://developers.google.com/analytics/devguides/reporting/core/v4/?sa=D&ust=1522637949796000) to determine the probability a page will be visited next. We lack:
   * (1) Page-level solution: a drop-in client-side solution for prefetching pages a user will likely visit


### PR DESCRIPTION
Hi,

currently, a link in the README is broken (probably due to `%23` instead of `#`).

I took the opportunity to fix it by linking directly to the timeline view, which (in my opinion) gives a clearer usage overview anyways.